### PR TITLE
chore: sync from source

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -41,7 +41,7 @@ get_source() {
 
 	echo "downloading sqlite source code; url=$sqlite_url; destDir=$ASDF_DOWNLOAD_PATH"
 
-	curl --silent "$sqlite_url" --output "$ASDF_DOWNLOAD_PATH/$sqlite_tarball"
+	curl -L --silent "$sqlite_url" --output "$ASDF_DOWNLOAD_PATH/$sqlite_tarball"
 	tar -xf "$ASDF_DOWNLOAD_PATH/$sqlite_tarball" --strip-components=1 -C "$ASDF_DOWNLOAD_PATH"
 }
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -16,5 +16,5 @@ echoerr() {
 }
 
 get_sqlite_url() {
-	curl --silent "$SQLITE_URL/$1"
+	curl -L --silent "$SQLITE_URL/$1"
 }


### PR DESCRIPTION
### Description
Sync upstream changes that follows HTTP redirects when pulling data from sqlite website

### Diagnosis
`mise install sqlite` fails with error
```
mise ERROR ~/.local/share/mise/plugins/sqlite/bin/download failed
```

Inspecting into `~/.local/share/mise/plugins/sqlite/bin/download` reveals that `curl` was not used with `-L` option (which allows it to follow redirects).

Looking at the upstream of `mise-sqlite`, `asdf-sqlite`, this issue [has been fixed](https://github.com/cLupus/asdf-sqlite/commit/eb591401459d6a6ea608c0f521663f011d9d3fe0). Hence, syncing the changes into `mise-sqlite`